### PR TITLE
Add CoinPaprika and DexPaprika to Analytics platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Thanks to all the [contributors](https://github.com/suenot/awesome-ccxt/graphs/c
 
 ## Analytics platforms
 
+- [CoinPaprika](https://api.coinpaprika.com) - free crypto market data API, 12,000+ coins, 350+ exchanges, tickers, OHLCV. No API key for free tier.
 - [CoinTop](https://github.com/fatihacet/CoinTop) - portfolio with secure access to keys
+- [DexPaprika](https://api.dexpaprika.com) - free DEX data API, 34 chains, 30M+ pools, 27M+ tokens, real-time streaming. No API key.
 - [DACP](https://github.com/Pyeskyhigh/DACP) - portfolio
 - [hodlwatch](https://github.com/belaczek/hodlwatch) - portfolio
 - [Live-Crypto-Dashboard-and-DB](https://github.com/srozov/Live-Crypto-Dashboard-and-DB) - python, sentiments

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Thanks to all the [contributors](https://github.com/suenot/awesome-ccxt/graphs/c
 
 ## Analytics platforms
 
-- [CoinPaprika](https://api.coinpaprika.com) - free crypto market data API, 12,000+ coins, 350+ exchanges, tickers, OHLCV. No API key for free tier.
+- [CoinPaprika](https://docs.coinpaprika.com) - crypto market data API covering 12,000+ coins and 350+ exchanges with tickers, OHLCV, and historical prices.
 - [CoinTop](https://github.com/fatihacet/CoinTop) - portfolio with secure access to keys
-- [DexPaprika](https://api.dexpaprika.com) - free DEX data API, 34 chains, 30M+ pools, 27M+ tokens, real-time streaming. No API key.
+- [DexPaprika](https://docs.dexpaprika.com) - DEX data API covering 34 chains with pool analytics, token metadata, OHLCV charts, and real-time streaming.
 - [DACP](https://github.com/Pyeskyhigh/DACP) - portfolio
 - [hodlwatch](https://github.com/belaczek/hodlwatch) - portfolio
 - [Live-Crypto-Dashboard-and-DB](https://github.com/srozov/Live-Crypto-Dashboard-and-DB) - python, sentiments


### PR DESCRIPTION
Adds two free crypto data APIs to the Analytics platforms section:

- **CoinPaprika** — 12,000+ coins, 350+ exchanges, tickers, OHLCV. Free, no API key.
- **DexPaprika** — DEX data across 34 chains, 30M+ pools, real-time streaming. Free, no API key.

Both complement CCXT by providing aggregated market data across exchanges and DEXes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CoinPaprika and DexPaprika to the Analytics platforms reference as linked services, describing CoinPaprika’s market coverage (12,000+ coins across 350+ exchanges) and DexPaprika’s DEX coverage (34 chains with pool analytics, token metadata, OHLCV charts and real-time streaming). Entries include concise coverage details; no existing entries were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->