### PR TITLE
Add DeepAlpha - AI crypto trading bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Thanks to all the [contributors](https://github.com/suenot/awesome-ccxt/graphs/c
 - [pine-bot-client](https://github.com/kzh-dev/pine-bot-client)
 - [cryptobot](https://github.com/Zane-/cryptobot) - lowhighbot, poolbot, releasebot
 - [ccxt-trader](https://github.com/Schnides123/ccxt-trader) - cryptocurrency arbitrage calculator on #python
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 3-model ML ensemble (XGBoost, HMM, Transformer), 70.9% walk-forward accuracy, 12 exchanges via CCXT. Cloud platform with dashboard and backtesting.
 - [KryptoBot](https://github.com/eristoddle/KryptoBot)
 - [blockbid-ccxt-tutorials](https://github.com/thomasdavis/blockbid-ccxt-tutorials)
 - [trader0](https://github.com/kebnekaise-io/trader0)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Thanks to all the [contributors](https://github.com/suenot/awesome-ccxt/graphs/c
 - [pine-bot-client](https://github.com/kzh-dev/pine-bot-client)
 - [cryptobot](https://github.com/Zane-/cryptobot) - lowhighbot, poolbot, releasebot
 - [ccxt-trader](https://github.com/Schnides123/ccxt-trader) - cryptocurrency arbitrage calculator on #python
-- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 3-model ML ensemble (XGBoost, HMM, Transformer), 70.9% walk-forward accuracy, 12 exchanges via CCXT. Cloud platform with dashboard and backtesting.
+- [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with 3-model ML ensemble (XGBoost, HMM, Transformer), reported 70.9% walk-forward accuracy, and 12 exchanges via CCXT. Includes dashboard and backtesting tools.
 - [KryptoBot](https://github.com/eristoddle/KryptoBot)
 - [blockbid-ccxt-tutorials](https://github.com/thomasdavis/blockbid-ccxt-tutorials)
 - [trader0](https://github.com/kebnekaise-io/trader0)


### PR DESCRIPTION
## Adding DeepAlpha

[DeepAlpha](https://github.com/stefanoviana/deepalpha) is an open-source AI crypto trading bot:

- **3-model ML ensemble** (XGBoost, HMM, Transformer) — 70.9% walk-forward accuracy
- **12 exchanges**: Bybit, Binance, OKX, Gate.io, KuCoin, Bitget, HTX, MEXC, BingX, Phemex, BitMart, WhiteBIT
- **Cloud platform** with dashboard, backtesting, TradingView webhooks
- **7-day free trial** — no credit card required
- **Open source** — PyPI: `pip install deepalpha-bot`
- **Non-custodial** — funds stay on user's exchange

Website: https://deepalphabot.com
GitHub: https://github.com/stefanoviana/deepalpha
PyPI: https://pypi.org/project/deepalpha-bot/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DeepAlpha to the trading bots section, including details about its AI trading model, exchange integration capabilities, and backtesting features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->